### PR TITLE
Synchronous reset

### DIFF
--- a/Hardware/FPGA/AEAD/Xoodyak_R2/src_rtl/CryptoCore.vhd
+++ b/Hardware/FPGA/AEAD/Xoodyak_R2/src_rtl/CryptoCore.vhd
@@ -777,11 +777,9 @@ begin
     ----------------------------------------------------------------------------
     --! Word, Byte and Block counters
     ----------------------------------------------------------------------------
-    p_counters : process(clk,rst)
+    p_counters : process(clk)
     begin
-        if (rst = '1') then
-            word_cnt_s      <= 0;
-        elsif rising_edge(clk) then
+        if rising_edge(clk) then
                 case state_s is
                     -- Nothing to do here, reset counters
                     when IDLE =>


### PR DESCRIPTION
While all other register in the FPGA implementation have synchronous resets, this one had an asynchronous reset. This could add an unnecessary asynchronous input timing constraint for synthesis. It turns out this reset is not required at all, as `word_cnt_s` is set to zero in state `state_s = IDLE` and also does not contribute to any of the flow control outputs during that state.